### PR TITLE
Update fstab.qcom for sd card as primary memory

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -14,6 +14,12 @@
 /dev/block/bootdevice/by-name/config         /persistent  emmc    defaults                                                    defaults
 /dev/block/bootdevice/by-name/modem          /firmware    vfat    ro,shortname=lower,uid=1000,gid=1026,dmask=227,fmask=337    wait
 
-/devices/soc.0/7864900.sdhci/mmc_host*       auto         auto    defaults                                                    voldmanaged=sdcard1:auto,encryptable=userdata
+# Setting to make external sd as primary storage for a6000
+#/devices/soc.0/7864900.sdhci/mmc_host*       auto        auto       defaults                                                  voldmanaged=sdcard0:auto,encryptable=userdata,noemulatedsd
+
+# Setting to make external sd as adoptable storage a6000+
+/devices/soc.0/7864900.sdhci/mmc_host*       auto      auto     defaults                                                      voldmanaged=sdcard1:auto,encryptable=userdata
+
+
 /devices/platform/msm_hsusb*                 auto         auto    defaults                                                    voldmanaged=usbdisk:auto
 /dev/block/zram0                             none         swap    defaults zramsize=536870912,max_comp_streams=3


### PR DESCRIPTION
Enable SDcard function as internal memory for low internal memory device A6000

The configuration can be kept default for a6000+ which has 16GB internal memory and doesn't generally experience storage running out problems

This is based on google documentation and can be applied in any low internal memory devices.
https://source.android.com/devices/storage/config-example

Woks on 'android 6.0' and ahead
